### PR TITLE
CODEOWNERS: owning team CLI (350)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# CODEOWNERS — default owner is the repository's owning team.
+# Managed by EngOps (scripts/sync-codeowners.js). Team: CLI (350).
+* @EENCloud/cli-350


### PR DESCRIPTION
Ensures **EEN-CLI-Public** has a CODEOWNERS file naming its owning team **CLI (350)** (`@EENCloud/cli-350`).

**Changes:** create .github/CODEOWNERS (@EENCloud/cli-350)

_Opened by `scripts/sync-codeowners.js` (EngOps). The owning team comes from `truths/repositories.json` → `truths/teams.json`._
